### PR TITLE
fix: omit leading v for version calculation

### DIFF
--- a/src/notes/requests.js
+++ b/src/notes/requests.js
@@ -53,15 +53,15 @@ module.exports = function requestsFactory() {
          */
         async resolveTaoCommunityComposer(version) {
             // Try to read composer.json via github tagged commit
-            log.doing(`Looking up tao-community v${version} on github`);
-            const fileUrl = `https://raw.githubusercontent.com/oat-sa/tao-community/v${version}/composer.json`;
+            log.doing(`Looking up tao-community ${version} on github`);
+            const fileUrl = `https://raw.githubusercontent.com/oat-sa/tao-community/${version}/composer.json`;
             try {
                 const response = await fetch(fileUrl);
                 const fileData = await response.json();
                 return fileData.require;
             }
             catch (err) {
-                log.error(`Could not resolve tao-community v${version}`);
+                log.error(`Could not resolve tao-community ${version}`);
                 log.error(err);
                 return {};
             }

--- a/src/releaseNotes.js
+++ b/src/releaseNotes.js
@@ -91,7 +91,8 @@ async function expandTaoCommunity(extensions = {}) {
     const community = 'oat-sa/tao-community';
 
     if (Object.keys(extensions).includes(community)) {
-        const tcVersion = extensions[community];
+	//omit leading `v` if specified
+        const tcVersion = extensions[community].replace(/^v/i, '');
         const resolvedExtensions = await requests.resolveTaoCommunityComposer(tcVersion);
         Object.assign(extensions, resolvedExtensions);
         delete extensions[community];

--- a/src/releaseNotes.js
+++ b/src/releaseNotes.js
@@ -39,6 +39,18 @@ function setupOutputDir() {
 }
 
 /**
+ * @param {String} version with leading `v` or without
+ * @returns {String}
+ */
+function normalizeVersion(version) {
+    //add leading v if missing
+    if(version[0] !== 'v') {
+        return `v${version}`;
+    }
+    return version;
+}
+
+/**
  * From 2 lists of composer dependencies, build the data structure which will hold
  * the list of all extensions with their name, starting and ending version
  * @param {Object} exts1
@@ -91,12 +103,11 @@ async function expandTaoCommunity(extensions = {}) {
     const community = 'oat-sa/tao-community';
 
     if (Object.keys(extensions).includes(community)) {
-	//omit leading `v` if specified
-        const tcVersion = extensions[community].replace(/^v/i, '');
+        const tcVersion = normalizeVersion(extensions[community]);
         const resolvedExtensions = await requests.resolveTaoCommunityComposer(tcVersion);
         Object.assign(extensions, resolvedExtensions);
         delete extensions[community];
-        log.done(`Retrieved ${Object.keys(resolvedExtensions).length} extension versions for tao-community v${tcVersion}.`);
+        log.done(`Retrieved ${Object.keys(resolvedExtensions).length} extension versions for tao-community ${tcVersion}.`);
     }
     return extensions;
 }

--- a/tests/unit/notes/requests/resolveTaoCommunityComposer/test.js
+++ b/tests/unit/notes/requests/resolveTaoCommunityComposer/test.js
@@ -42,7 +42,7 @@ test('the module api', t => {
 
 test('returns data from tao-community', async t => {
     t.plan(1);
-    const tcVersion = '0.121.0-alpha';
+    const tcVersion = 'v0.121.0-alpha';
     const res = await requests.resolveTaoCommunityComposer(tcVersion);
     t.deepEqual(
         res,

--- a/tests/unit/releaseNotes/normalizeVersion/test.js
+++ b/tests/unit/releaseNotes/normalizeVersion/test.js
@@ -1,0 +1,38 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA;
+ */
+
+/**
+ * Unit test the function normalizeVersion of the module src/releaseNotes.js
+ *
+ * @author Andrey Shaveko <andrey.shaveko@taotesting.com>
+ */
+
+const test = require('tape');
+const rewire = require('rewire');
+const releaseNotes = rewire('../../../../src/releaseNotes.js');
+
+// Private function under test:
+const normalizeVersion = releaseNotes.__get__('normalizeVersion');
+
+test('version normalization', t => {
+    t.plan(3);
+    t.ok(typeof normalizeVersion === 'function', 'The normalizeVersion function exists');
+    t.ok(normalizeVersion('v0.1.1-alpha') === 'v0.1.1-alpha', 'leading `v` is not added if exists');
+    t.ok(normalizeVersion('0.1.1-alpha') === 'v0.1.1-alpha', 'leading `v` is added if does not exist');
+    t.end();
+});


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TRN-972

### Description

Tool parses input comoser file, checking the version value for "oat-sa/tao-community". Tool failed if version vas specified using leading `v` because it expects to receive version without leading `v`. 

The change makes tool accept both version - with leading `v` and without

### How to test

- `npm run test`

- try running tool with files attached `taoReleaseNotes composers --c1 composer117.json --c2 composer134.json`

files are here : https://oat-sa.atlassian.net/browse/TRN-972?focusedCommentId=142791